### PR TITLE
Add mips as one of the supported instruction sets

### DIFF
--- a/Target_Platforms/Embedded-SIG-Target-Platforms.md
+++ b/Target_Platforms/Embedded-SIG-Target-Platforms.md
@@ -30,6 +30,7 @@ The following hardware instructions sets should be supported:
 2. RISC-V 32-bit + 64-bit
 3. ARM 32-bit + 64-bit
 4. X86-64 bit
+5. MIPS 32-bit
 
 ## 2. MMU / MPU Support
 


### PR DESCRIPTION
We haven't discussed it in the meeting but a subset of devices we currently support is based on the MIPS ISA so I'm proposing adding it here as yet another supported instruction set. I do understand it's not as popular as the other ISAs listed in the doc, so I'm open for discussion. 